### PR TITLE
Weaken procrustean assertions in build_universe()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: r.releases.utils
 Title: Utilities for An R Universe of Package Releases
 Description: Utilities for an R universe of package releases.
-Version: 0.0.3
+Version: 0.0.4
 License: MIT + file LICENSE
 URL:
   https://r-releases.github.io/r.releases.utils/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# r.releases.utils 0.0.4
+
+* Relax some assertions so `build_universe()` can run on reasonable cases.
+
 # r.releases.utils 0.0.3
 
 * Checks URL matches the package description for CRAN packages.

--- a/R/assert_package.R
+++ b/R/assert_package.R
@@ -8,12 +8,10 @@
 #' @param url Usually a character of length 1 with the package URL.
 #'   Can also be a custom JSON string with the package URL and other metadata,
 #'   but this is for rare cases and flags the package for manual review.
-#' @param assert_cran_url Logical of length 1, whether to check
-#'   the alignment between the specified URL and the CRAN URL.
-assert_package <- function(name, url, assert_cran_url = TRUE) {
-  if (!is_package_name(name)) {
-    return("Invalid package name.")
-  }
+#' @param strict Logical of length 1, whether to run strict and expensive
+#'   checks such as checking the alignment between the specified
+#'   URL and the CRAN URL.
+assert_package <- function(name, url) {
   json <- try(jsonlite::parse_json(json = url), silent = TRUE)
   if (!inherits(json, "try-error")) {
     return(
@@ -24,24 +22,13 @@ assert_package <- function(name, url, assert_cran_url = TRUE) {
       )
     )
   }
-  if (!is_character_scalar(url)) {
-    return("Invalid package URL.")
+  out <- assert_package_lite(name = name, url = url)
+  if (!is.null(out)) {
+    return(out)
   }
   name <- trimws(name)
   url <- trimws(trim_trailing_slash(url))
-  valid_package_name <- grepl(
-    pattern = "^[a-zA-Z][a-zA-Z0-9.]*[a-zA-Z0-9]$",
-    x = name
-  )
-  if (!isTRUE(valid_package_name)) {
-    return(paste("Found invalid package name:", shQuote(name)))
-  }
   parsed_url <- try(url_parse(url), silent = TRUE)
-  if (inherits(parsed_url, "try-error")) {
-    return(
-      paste("Found malformed URL", shQuote(url), "of package", shQuote(name))
-    )
-  }
   if (!identical(name, basename(parsed_url[["path"]]))) {
     return(
       paste(
@@ -51,9 +38,6 @@ assert_package <- function(name, url, assert_cran_url = TRUE) {
         shQuote(url)
       )
     )
-  }
-  if (!identical(parsed_url[["scheme"]], "https")) {
-    return(paste("Scheme of URL", shQuote(url), "is not https."))
   }
   if (!(parsed_url[["hostname"]] %in% c("github.com", "gitlab.com"))) {
     return(paste("URL", shQuote(url), "is not a GitHub or GitLab URL."))
@@ -73,8 +57,26 @@ assert_package <- function(name, url, assert_cran_url = TRUE) {
   if (identical(owner, "cran")) {
     return(paste("URL", shQuote(url), "appears to use a CRAN mirror."))
   }
-  if (assert_cran_url) {
-    return(assert_cran_url(name = name, url = url))
+  assert_cran_url(name = name, url = url)
+}
+
+assert_package_lite <- function(name, url) {
+  if (!is_package_name(name)) {
+    return("Invalid package name.")
+  }
+  if (!is_character_scalar(url)) {
+    return("Invalid package URL.")
+  }
+  name <- trimws(name)
+  url <- trimws(trim_trailing_slash(url))
+  parsed_url <- try(url_parse(url), silent = TRUE)
+  if (inherits(parsed_url, "try-error")) {
+    return(
+      paste("Found malformed URL", shQuote(url), "of package", shQuote(name))
+    )
+  }
+  if (!identical(parsed_url[["scheme"]], "https")) {
+    return(paste("Scheme of URL", shQuote(url), "is not https."))
   }
 }
 

--- a/R/assert_package.R
+++ b/R/assert_package.R
@@ -6,20 +6,10 @@
 #'   otherwise `NULL` if there are no issues.
 #' @param name Character of length 1, package name.
 #' @param url Usually a character of length 1 with the package URL.
-#'   Can also be a custom JSON string with the package URL and other metadata,
-#'   but this is for rare cases and flags the package for manual review.
-#' @param strict Logical of length 1, whether to run strict and expensive
-#'   checks such as checking the alignment between the specified
-#'   URL and the CRAN URL.
 assert_package <- function(name, url) {
-  json <- try(jsonlite::parse_json(json = url), silent = TRUE)
-  if (!inherits(json, "try-error")) {
+  if (any(grepl(pattern = "\\}|\\{", x = url))) {
     return(
-      paste(
-        "Entry of package",
-        shQuote(name),
-        "looks like custom JSON"
-      )
+      paste("Entry of package", shQuote(name), "looks like custom JSON")
     )
   }
   out <- assert_package_lite(name = name, url = url)

--- a/R/build_universe.R
+++ b/R/build_universe.R
@@ -38,11 +38,7 @@ read_package_entry <- function(package) {
 }
 
 package_entry_url <- function(name, url) {
-  message <- assert_package(
-    name = name,
-    url = url,
-    assert_cran_url = FALSE # Prevents massive slowdown from 20000+ packages.
-  )
+  message <- assert_package_lite(name = name, url = url)
   if (!is.null(message)) {
     stop(message, call. = FALSE)
   }

--- a/R/build_universe.R
+++ b/R/build_universe.R
@@ -91,5 +91,9 @@ package_entry_json <- function(name, json) {
     )
     json[[field]] <- trimws(json[[field]])
   }
+  message <- assert_package_lite(name = json$package, url = json$url)
+  if (!is.null(message)) {
+    stop(message, call. = FALSE)
+  }
   as.data.frame(json)
 }

--- a/man/assert_package.Rd
+++ b/man/assert_package.Rd
@@ -4,7 +4,7 @@
 \alias{assert_package}
 \title{Validate a Package Entry}
 \usage{
-assert_package(name, url, assert_cran_url = TRUE)
+assert_package(name, url)
 }
 \arguments{
 \item{name}{Character of length 1, package name.}
@@ -13,8 +13,9 @@ assert_package(name, url, assert_cran_url = TRUE)
 Can also be a custom JSON string with the package URL and other metadata,
 but this is for rare cases and flags the package for manual review.}
 
-\item{assert_cran_url}{Logical of length 1, whether to check
-the alignment between the specified URL and the CRAN URL.}
+\item{strict}{Logical of length 1, whether to run strict and expensive
+checks such as checking the alignment between the specified
+URL and the CRAN URL.}
 }
 \value{
 A character string if there is a problem with the package entry,

--- a/man/assert_package.Rd
+++ b/man/assert_package.Rd
@@ -9,13 +9,7 @@ assert_package(name, url)
 \arguments{
 \item{name}{Character of length 1, package name.}
 
-\item{url}{Usually a character of length 1 with the package URL.
-Can also be a custom JSON string with the package URL and other metadata,
-but this is for rare cases and flags the package for manual review.}
-
-\item{strict}{Logical of length 1, whether to run strict and expensive
-checks such as checking the alignment between the specified
-URL and the CRAN URL.}
+\item{url}{Usually a character of length 1 with the package URL.}
 }
 \value{
 A character string if there is a problem with the package entry,

--- a/tests/test-assert_package.R
+++ b/tests/test-assert_package.R
@@ -20,10 +20,15 @@ stopifnot(
 stopifnot(
   grepl(
     "looks like custom JSON",
-    r.releases.utils::assert_package(
-      name = "xy",
-      url = "{\"branch\": \"release\"}"
-    ),
+    r.releases.utils::assert_package(name = "xy", url = "{"),
+    fixed = TRUE
+  )
+)
+
+stopifnot(
+  grepl(
+    "looks like custom JSON",
+    r.releases.utils::assert_package(name = "xy", url = "}"),
     fixed = TRUE
   )
 )

--- a/tests/test-build_universe.R
+++ b/tests/test-build_universe.R
@@ -77,6 +77,36 @@ stopifnot(identical(out, exp))
 unlink(packages, recursive = TRUE)
 unlink(universe)
 
+
+# Malformed URL in JSON.
+packages <- tempfile()
+dir.create(packages)
+writeLines("https://github.com/r-lib/gh", file.path(packages, "gh"))
+writeLines(
+  c(
+    "{",
+    "  \"package\": \"paws.analytics\",",
+    "  \"url\": \"b a d u r l\",",
+    "  \"subdir\": \"cran/paws.analytics\",",
+    "  \"branch\": \"*release\"",
+    "}"
+  ),
+  file.path(packages, "paws.analytics")
+)
+universe <- file.path(tempfile(), "out")
+out <- try(
+  r.releases.utils::build_universe(input = packages, output = universe),
+  silent = TRUE
+)
+stopifnot(
+  grepl(
+    pattern = "Found malformed URL",
+    x = r.releases.utils::try_message(out)
+  )
+)
+unlink(packages, recursive = TRUE)
+unlink(universe)
+
 # Missing branch field
 packages <- tempfile()
 dir.create(packages)


### PR DESCRIPTION
`build_universe()` is not currently building because the assertions are overly strong. This PR weakens enough assertions to get `build_universe()` to run locally, while keeping all those assertions in tact for reviewing pull requests, and it also improves JSON detection in those reviews. Using this PR, https://github.com/r-releases/r-releases/tree/main/packages builds for me locally. 

@shikokuchuo, would you please review? I think we need it in order to get the automated checks back online.