### PR TITLE
Check status code before trying to use the redirect location

### DIFF
--- a/R/assert_package.R
+++ b/R/assert_package.R
@@ -123,6 +123,17 @@ assert_release_exists <- function(url) {
     file.path(url, "releases", "latest"),
     convert = FALSE
   )
+  status <- response[["status"]]
+  if (status != 302L) {
+    return(
+      paste(
+        "Checking releases at",
+        shQuote(url),
+        "returned HTTP error",
+        nanonext::status_code(status)
+      )
+    )
+  }
   found <- identical(
     dirname(as.character(response$headers$Location)),
     file.path(url, "releases", "tag")


### PR DESCRIPTION
Defensive programming - should generally check the status code otherwise the format of what we expect to be returned can be different.