### PR TITLE
Fixes packages with no URL listed in description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: r.releases.utils
 Title: Utilities for An R Universe of Package Releases
 Description: Utilities for an R universe of package releases.
-Version: 0.0.8
+Version: 0.0.8.9000
 License: MIT + file LICENSE
 URL:
   https://r-releases.github.io/r.releases.utils/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# r.releases.utils 0.0.8.9000 (development)
+
+* Makes `review_pull_requests()` robust to a package description with no URL listed.
+
 # r.releases.utils 0.0.8
 
 * Use R-releases and not `r-releases` to refer to the project.

--- a/R/assert_cran_url.R
+++ b/R/assert_cran_url.R
@@ -16,7 +16,13 @@ assert_cran_url <- function(name, url) {
     return(invisible())
   }
   package <- result[["Package"]]
-  main_urls <- strsplit(result[["URL"]], ",\n|, |\n", perl = TRUE)[[1L]]
+  main_urls <- unlist(
+    strsplit(
+      as.character(result[["URL"]]),
+      ",\n|, |\n",
+      perl = TRUE
+    )
+  )
   bugs_url <- sub(
     pattern = "/issues/*$",
     replacement = "",

--- a/tests/test-assert_package.R
+++ b/tests/test-assert_package.R
@@ -142,6 +142,17 @@ stopifnot(
 
 stopifnot(
   grepl(
+    "does not appear in its DESCRIPTION file published on CRAN",
+    r.releases.utils::assert_cran_url(
+      name = "assertthat",
+      url = "https://github.com/hadley/assertthat"
+    ),
+    fixed = TRUE
+  )
+)
+
+stopifnot(
+  grepl(
     "returned HTTP error",
     r.releases.utils::assert_package(
       name = "afantasticallylongandimpossiblepackage",


### PR DESCRIPTION
Fixes error caused by trying to strsplit NULL as in here: https://github.com/r-releases/r-releases.r-universe.dev/actions/runs/8163847920/job/22317950694

Also adds this specific case as a test.